### PR TITLE
Settings form

### DIFF
--- a/src/app/default/default.component.css
+++ b/src/app/default/default.component.css
@@ -1,3 +1,26 @@
+*{
+  font-family: Arial, Helvetica, sans-serif;
+}
+
 .defaultText {
   font-size: 4vmin;
+}
+
+.formText {
+  font-size: 3.5vmin;
+}
+
+.formApi{
+  width: 50%;
+  height: 3vmin
+}
+
+.formDefault{
+  width: 10%;
+  font-size: 3vmin;
+  margin-right: 5%;
+}
+
+.divCentered{
+  text-align: center;
 }

--- a/src/app/default/default.component.html
+++ b/src/app/default/default.component.html
@@ -1,5 +1,35 @@
-<h3 class="defaultText">{{MainText}}</h3>
+<h3 class="defaultText">You appear to not have entered in all of the values required for this app to run. Either check the values above or use the form below to get this up and running!</h3>
 <br/><br/>
+<form>
+  <label for="apikey">API Key: </label>
+  <input type="text" name="apikey" id="apikey" value="{{apiKey}}" required />
+  <label for="lat">Lat: </label>
+  <input type="text" name="lat" id="lat" value="{{lat}}" required />
+  <label for="long">Long: </label>
+  <input type="text" name="long" id="long" value="{{long}}" required />
+  <br/><br/>
+
+  <label for="selectlang">Language: </label>
+  <select name="selectlang" id="selectlang" (change)="langChange($event)">
+    <option value="" selected disabled hidden>Select lang</option>
+    <option *ngFor="let language of weatherService.genLangList()" value={{language}} >{{language}}</option>
+  </select>
+
+  <label for="selectunits">Unit type: </label>
+  <select name="selectunits" id="selectunits" (change)="unitChange($event)">
+    <option value="" selected disabled hidden>Select unit</option>
+    <option *ngFor="let unit of weatherService.genUnitList()" value={{unit}} >{{unit}}</option>
+  </select>
+
+  <label for="selectsummary">Summary type: </label>
+  <select name="selectsummary" id="selectsummary" (change)="summaryChange($event)">
+    <option value="" selected disabled hidden>Select unit</option>
+    <option *ngFor="let summary of summaryList" value={{summary}} >{{summary}}</option>
+  </select>
+
+  <label for="minlong">Time between updates: </label>
+  <input type="text" name="minlong" id="minlong" value="{{minLong}}" />
+</form>
 <a href="https://darksky.net/dev/account" class="defaultText">Darksky site to get API key</a> <br/> <br/>
 <a href="https://www.latlong.net/" class="defaultText">Site to obtain lat and long of location</a> <br/> <br/>
 <a href="https://github.com/2haloes/Angular-Weather-Display" class="defaultText">Angular Weather Display github</a>

--- a/src/app/default/default.component.html
+++ b/src/app/default/default.component.html
@@ -1,35 +1,49 @@
 <h3 class="defaultText">You appear to not have entered in all of the values required for this app to run. Either check the values above or use the form below to get this up and running!</h3>
-<br/><br/>
-<form>
-  <label for="apikey">API Key: </label>
-  <input type="text" name="apikey" id="apikey" value="{{apiKey}}" required />
-  <label for="lat">Lat: </label>
-  <input type="text" name="lat" id="lat" value="{{lat}}" required />
-  <label for="long">Long: </label>
-  <input type="text" name="long" id="long" value="{{long}}" required />
+<br/>
+  <div class="divCentered">
+    <label for="apikey" class="formText">API Key: </label>
+    <input type="text" name="apikey" id="apikey" value="{{apiKey}}" required maxlength=32 minlength=32 class="formApi"/>
+  </div>
+
+  <br/><br/><br/>
+  <div class="divCentered">
+    <label for="lat" class="formText">Lat: </label>
+    <input type="text" name="lat" id="lat" value="{{lat}}" required class="formDefault"/>
+
+    <label for="long" class="formText">Long: </label>
+    <input type="text" name="long" id="long" value="{{lon}}" required class="formDefault"/>
+
+
+    <label for="selectlang" class="formText">Language: </label>
+    <select name="selectlang" id="selectlang" (change)="langChange($event)" class="formDefault">
+      <option value="" selected disabled hidden>Select lang</option>
+      <option *ngFor="let language of weatherService.genLangList()" value={{language}} >{{language}}</option>
+    </select>
+  </div>
+
   <br/><br/>
 
-  <label for="selectlang">Language: </label>
-  <select name="selectlang" id="selectlang" (change)="langChange($event)">
-    <option value="" selected disabled hidden>Select lang</option>
-    <option *ngFor="let language of weatherService.genLangList()" value={{language}} >{{language}}</option>
-  </select>
+  <div class="divCentered">
+    <label for="selectunits" class="formText">Unit type: </label>
+    <select name="selectunits" id="selectunits" (change)="unitChange($event)" class="formDefault">
+      <option value="" selected disabled hidden>Select unit</option>
+      <option *ngFor="let unit of weatherService.genUnitList()" value={{unit}} >{{unit}}</option>
+    </select>
 
-  <label for="selectunits">Unit type: </label>
-  <select name="selectunits" id="selectunits" (change)="unitChange($event)">
-    <option value="" selected disabled hidden>Select unit</option>
-    <option *ngFor="let unit of weatherService.genUnitList()" value={{unit}} >{{unit}}</option>
-  </select>
+    <label for="selectsummary" class="formText">Summary type: </label>
+    <select name="selectsummary" id="selectsummary" (change)="summaryChange($event)" class="formDefault">
+      <option value="" selected disabled hidden>Select summary type</option>
+      <option *ngFor="let summary of summaryList" value={{summary}} >{{summary}}</option>
+    </select>
 
-  <label for="selectsummary">Summary type: </label>
-  <select name="selectsummary" id="selectsummary" (change)="summaryChange($event)">
-    <option value="" selected disabled hidden>Select unit</option>
-    <option *ngFor="let summary of summaryList" value={{summary}} >{{summary}}</option>
-  </select>
-
-  <label for="minlong">Time between updates: </label>
-  <input type="text" name="minlong" id="minlong" value="{{minLong}}" />
-</form>
+    <label for="minlong" class="formText">Time between updates: </label>
+    <input type="text" name="minlong" id="minlong" value="{{minLong}}" class="formDefault"/>
+  </div>
+  <br/><br/>
+  <div class="divCentered">
+    <input type="submit" value="Load"  class="formDefault" (click)="onSubmit()"/>
+  </div>
+<br/><br/>
 <a href="https://darksky.net/dev/account" class="defaultText">Darksky site to get API key</a> <br/> <br/>
 <a href="https://www.latlong.net/" class="defaultText">Site to obtain lat and long of location</a> <br/> <br/>
 <a href="https://github.com/2haloes/Angular-Weather-Display" class="defaultText">Angular Weather Display github</a>

--- a/src/app/default/default.component.ts
+++ b/src/app/default/default.component.ts
@@ -1,5 +1,6 @@
 import { ActivatedRoute } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
+import { WeatherServiceService } from '../weather-service.service';
 
 @Component({
   selector: 'app-default',
@@ -8,25 +9,43 @@ import { Component, OnInit } from '@angular/core';
 })
 export class DefaultComponent implements OnInit {
 
-  constructor(private route: ActivatedRoute) { }
+  constructor(public weatherService: WeatherServiceService, private route: ActivatedRoute) { }
 
   apiKey: string;
   lat: string;
-  MainText: string;
+  lon: string;
+  lang: string;
+  units: string;
+  summary: string;
+  minLong: string;
+  summaryList = [
+    'currently',
+    'minutely',
+    'weeklong'
+  ];
 
   ngOnInit() {
-    this.apiKey = this.route.snapshot.paramMap.get('key');
-    this.lat = this.route.snapshot.paramMap.get('lat');
+    this.apiKey = this.route.snapshot.paramMap.get('key'),
+    this.lang = this.route.snapshot.paramMap.get('lang'),
+    this.lat = this.route.snapshot.paramMap.get('lat'),
+    this.lon = this.route.snapshot.paramMap.get('lon'),
+    this.units = this.route.snapshot.paramMap.get('units'),
+    this.summary = this.route.snapshot.paramMap.get('summary');
+    this.minLong = this.route.snapshot.paramMap.get('minLong');
 
-    if (!!this.apiKey) {
-      if (!!this.lat) {
-        this.MainText = 'The URL is currently missing the longitude number, this can be appiled by adding "/[long]" to the end of the website address. If you do not know this then use the link below to find the lat and long of the location';
-      } else {
-        this.MainText = 'The URL is currently missing the latitude and longitude numbers, this can be appiled by adding "/[lat]/[long]" to the end of the website address. If you do not know this then use the link below to find the lat and long of the location';
-      }
-    } else {
-      this.MainText = 'The URL is currently missing the API key, this is required for the application to pull data from the Darksky API, this can be applied by adding "/[API key]" to the end of the website address. If you do not have one or do not know what it is then use the link below to either create an account or to copy your key from'
-    }
+    this.units = 'uk2';
+  }
+  public langChange(event): void{
+    this.lang = event.target.value;
+  }
+
+  public unitChange(event): void{
+    this.units = event.target.value;
+  }
+
+  public summaryChange(event): void{
+    this.summary = event.target.value;
+    console.log(this.summary);
   }
 
 }

--- a/src/app/default/default.component.ts
+++ b/src/app/default/default.component.ts
@@ -1,4 +1,4 @@
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
 import { WeatherServiceService } from '../weather-service.service';
 
@@ -9,7 +9,7 @@ import { WeatherServiceService } from '../weather-service.service';
 })
 export class DefaultComponent implements OnInit {
 
-  constructor(public weatherService: WeatherServiceService, private route: ActivatedRoute) { }
+  constructor(public weatherService: WeatherServiceService, private route: ActivatedRoute, private router: Router) { }
 
   apiKey: string;
   lat: string;
@@ -46,6 +46,24 @@ export class DefaultComponent implements OnInit {
   public summaryChange(event): void{
     this.summary = event.target.value;
     console.log(this.summary);
+  }
+
+  onSubmit(){
+    let extraParams = [];
+
+    if (!!this.minLong && !isNaN(+this.minLong)) {
+      extraParams.push({minLong: this.minLong});
+    }
+    if (!!this.units && this.weatherService.genUnitList().includes(this.units)) {
+      extraParams.push({units: this.units});
+    }
+    if (!!this.lang && this.weatherService.genLangList().includes(this.lang)) {
+      extraParams.push({lang: this.lang});
+    }
+    if (!!this.summary && this.summaryList.includes(this.summary)) {
+      extraParams.push({summary: this.summary});
+    }
+    this.router.navigate([`/${this.apiKey}/${this.lat}/${this.lon}`], {queryParams: extraParams});
   }
 
 }


### PR DESCRIPTION
Adds a form to input settings if the URL does not contain the API key, lat and long.

It allows setting options without having to use the Angular URL syntax 

The form makes sure that only valid details are passed on (However number checking has been strange but it seems to work)

The default component has also had CSS added so that the page looks better and it more fits the style of the main display